### PR TITLE
Added which-key requirement + minor cosmetics

### DIFF
--- a/README.org
+++ b/README.org
@@ -72,7 +72,7 @@ bash <(curl -Ls https://raw.githubusercontent.com/otavioschwanck/doom-emacs-on-r
 #+BEGIN_SRC shell
 # Install my config
 git clone --depth 1 https://github.com/hlissner/doom-emacs ~/.emacs.d
-git clone https://github.com/otavioschwanck/doom_emacs_dotfiles.git ~/.doom.d
+git clone https://github.com/0tt049/doom-emacs-on-rails ~/.doom.d
 ~/.emacs.d/bin/doom install
 
 # if you use Ubuntu

--- a/config.el
+++ b/config.el
@@ -1,17 +1,17 @@
 ;;; $DOOMDIR/config.el -*- lexical-binding: t; -*-
 
-(load (expand-file-name "modules/editor.el" doom-private-dir))
-(load (expand-file-name "modules/misc.el" doom-private-dir))
-(load (expand-file-name "modules/ruby.el" doom-private-dir))
-(load (expand-file-name "modules/ruby-autocomplete.el" doom-private-dir))
-(load (expand-file-name "modules/term.el" doom-private-dir))
-(load (expand-file-name "modules/git.el" doom-private-dir))
-(load (expand-file-name "modules/lsp.el" doom-private-dir))
-(load (expand-file-name "modules/org.el" doom-private-dir))
-(load (expand-file-name "modules/autocomplete.el" doom-private-dir))
+(load (expand-file-name "modules/editor.el" doom-user-dir))
+(load (expand-file-name "modules/misc.el" doom-user-dir))
+(load (expand-file-name "modules/ruby.el" doom-user-dir))
+(load (expand-file-name "modules/ruby-autocomplete.el" doom-user-dir))
+(load (expand-file-name "modules/term.el" doom-user-dir))
+(load (expand-file-name "modules/git.el" doom-user-dir))
+(load (expand-file-name "modules/lsp.el" doom-user-dir))
+(load (expand-file-name "modules/org.el" doom-user-dir))
+(load (expand-file-name "modules/autocomplete.el" doom-user-dir))
 
 (if (not (file-exists-p "~/.doom.d/user/config.el"))
     (progn
       (shell-command "cp ~/.doom.d/user/examples/config.el ~/.doom.d/user/config.el")
-      (load (expand-file-name "user/config.el" doom-private-dir)))
-  (load (expand-file-name "user/config.el" doom-private-dir)))
+      (load (expand-file-name "user/config.el" doom-user-dir)))
+  (load (expand-file-name "user/config.el" doom-user-dir)))

--- a/init.el
+++ b/init.el
@@ -76,8 +76,8 @@
        :config
        (default +bindings +smartparens))
 
-(if (file-exists-p (expand-file-name "user/init.el" doom-private-dir))
-    (load (expand-file-name "user/init.el" doom-private-dir))
+(if (file-exists-p (expand-file-name "user/init.el" doom-user-dir))
+    (load (expand-file-name "user/init.el" doom-user-dir))
   (progn
     (shell-command "cp ~/.doom.d/user/examples/init.el ~/.doom.d/user/init.el")
-    (load (expand-file-name "user/init.el" doom-private-dir))))
+    (load (expand-file-name "user/init.el" doom-user-dir))))

--- a/packages.el
+++ b/packages.el
@@ -11,8 +11,8 @@
 
 (package! string-inflection :pin "fd7926ac17293e9124b31f706a4e8f38f6a9b855")
 
-(if (file-exists-p (expand-file-name "user/packages.el" doom-private-dir))
-    (load (expand-file-name "user/packages.el" doom-private-dir))
+(if (file-exists-p (expand-file-name "user/packages.el" doom-user-dir))
+    (load (expand-file-name "user/packages.el" doom-user-dir))
   (progn
     (shell-command "cp ~/.doom.d/user/examples/packages.el ~/.doom.d/user/packages.el")
-    (load (expand-file-name "user/packages.el" doom-private-dir))))
+    (load (expand-file-name "user/packages.el" doom-user-dir))))

--- a/user/examples/config.el
+++ b/user/examples/config.el
@@ -30,6 +30,7 @@
 ;; You can send any text to any terminal by selecting and pressing SPC l
 ;; You can quickly execute a define command with SPC j + the keybinding you defined.
 
+(require 'which-key) ;; Needed for which-key to work
 (after! which-key
   ;;                         | Name              | command                      | Keybinding |
   (+add-command-to-term-list '("Docker Compose" . "docker-compose up") "u") ;; SPC j u


### PR DESCRIPTION
I've noticed which-key wasn't working after the first installation of Doom + DoR.
```elisp
;; -- user/config.el --
(after! which-key ;; This was giving an error >>> Symbol's value as variable is void: which-key 

```
All else was just cosmetics
```elisp
doom-private-dir ;; deprecated
doom-user-dir ;; new form.
```
BTW, this is my first proper open source contrib. I've just finished a BootCamp at Le Wagon, and this config was great, I was the only one using Emacs in class, though. 