### PR TITLE
Update path to use .config in modern installations

### DIFF
--- a/README.org
+++ b/README.org
@@ -71,9 +71,9 @@ bash <(curl -Ls https://raw.githubusercontent.com/otavioschwanck/doom-emacs-on-r
 * Manual Instalation
 #+BEGIN_SRC shell
 # Install my config
-git clone --depth 1 https://github.com/hlissner/doom-emacs ~/.emacs.d
-git clone https://github.com/0tt049/doom-emacs-on-rails ~/.doom.d
-~/.emacs.d/bin/doom install
+git clone --depth 1 https://github.com/hlissner/doom-emacs ~/.config/emacs
+git clone https://github.com/0tt049/doom-emacs-on-rails ~/.config/doom
+~/.config/emacs/bin/doom install
 
 # if you use Ubuntu
 sudo apt install fd-find ripgrep libtool-bin cmake tidy

--- a/auto-installer.sh
+++ b/auto-installer.sh
@@ -117,9 +117,9 @@ install_emacs_mac () {
 
 install_emacs_doom () {
   echo "================= INSTALLING DOOM ================="
-  git clone --quiet --depth 1 $DOOM_GIT ~/.emacs.d
-  git clone --quiet $DOTFILES_GIT ~/.doom.d
-  ~/.emacs.d/bin/doom install
+  git clone --quiet --depth 1 $DOOM_GIT ~/.config/emacs
+  git clone --quiet $DOTFILES_GIT ~/.config/doom
+  ~/.config/emacs/bin/doom install
 }
 
 linux_workflow () {

--- a/config.el
+++ b/config.el
@@ -10,8 +10,8 @@
 (load (expand-file-name "modules/org.el" doom-user-dir))
 (load (expand-file-name "modules/autocomplete.el" doom-user-dir))
 
-(if (not (file-exists-p "~/.doom.d/user/config.el"))
+(if (not (file-exists-p "~/.config/doom/user/config.el"))
     (progn
-      (shell-command "cp ~/.doom.d/user/examples/config.el ~/.doom.d/user/config.el")
+      (shell-command "cp ~/.config/doom/user/examples/config.el ~/.config/doom/user/config.el")
       (load (expand-file-name "user/config.el" doom-user-dir)))
   (load (expand-file-name "user/config.el" doom-user-dir)))

--- a/docs/emacs-handbook.org
+++ b/docs/emacs-handbook.org
@@ -10,13 +10,13 @@ Learn the basics of vim keybindings using [[elisp:(evil-tutor-start)][evil-tutor
 To do some exercises, visit [[elisp:(open-mr-miyagi)][mr-miyagi]]
 
 * Customizing your emacs
-To add some elisp code of your own, visit [[file:~/.doom.d/user/config.el][config.el]] (SPC f m).  It is the same as config.el for normal doom.
-[[file:~/.doom.d/user/config.el][config.el]] has a lot of cool stuff and examples of stuff like disabling rubocop, adding commands to [[Single Commands][terminal]] (SPC o t), etc.
+To add some elisp code of your own, visit [[file:~/.config/doom/user/config.el][config.el]] (SPC f m).  It is the same as config.el for normal doom.
+[[file:~/.config/doom/user/config.el][config.el]] has a lot of cool stuff and examples of stuff like disabling rubocop, adding commands to [[Single Commands][terminal]] (SPC o t), etc.
 
 To add some module (like another programming language),
-visit [[file:~/.doom.d/init.el][init.el]] (SPC f i) and uncomment the module that you want (and then, run doom sync or M-x [[elisp:(upgrade-doom-emacs-on-rails)][upgrade-doom-emacs-on-rails]])
+visit [[file:~/.config/doom/init.el][init.el]] (SPC f i) and uncomment the module that you want (and then, run doom sync or M-x [[elisp:(upgrade-doom-emacs-on-rails)][upgrade-doom-emacs-on-rails]])
 
-To add some external package, visit [[file:~/.doom.d/packages.el][packages.el]] (SPC f I)
+To add some external package, visit [[file:~/.config/doom/packages.el][packages.el]] (SPC f I)
 
 * Index :TOC:
 - [[#quick-tips][Quick Tips]]

--- a/init.el
+++ b/init.el
@@ -79,5 +79,5 @@
 (if (file-exists-p (expand-file-name "user/init.el" doom-user-dir))
     (load (expand-file-name "user/init.el" doom-user-dir))
   (progn
-    (shell-command "cp ~/.doom.d/user/examples/init.el ~/.doom.d/user/init.el")
+    (shell-command "cp ~/.config/doom/user/examples/init.el ~/.config/doom/user/init.el")
     (load (expand-file-name "user/init.el" doom-user-dir))))

--- a/modules/misc.el
+++ b/modules/misc.el
@@ -138,8 +138,8 @@ Version 2015-06-08"
 (map! :leader :desc "Visit User Init" "fi" 'visit-user-init)
 (map! :leader :desc "Visit User Packages" "fI" 'visit-user-packages)
 
-(when (not (file-exists-p "~/.pryrc")) (shell-command "cp ~/.doom.d/user/examples/.pry-example ~/.pryrc"))
-(when (not (file-exists-p "~/.irbrc")) (shell-command "cp ~/.doom.d/user/examples/.irbrc-example ~/.irbrc"))
+(when (not (file-exists-p "~/.pryrc")) (shell-command "cp ~/.config/doom/user/examples/.pry-example ~/.pryrc"))
+(when (not (file-exists-p "~/.irbrc")) (shell-command "cp ~/.config/doom/user/examples/.irbrc-example ~/.irbrc"))
 
 (defun open-mr-miyagi ()
   (interactive)

--- a/packages.el
+++ b/packages.el
@@ -14,5 +14,5 @@
 (if (file-exists-p (expand-file-name "user/packages.el" doom-user-dir))
     (load (expand-file-name "user/packages.el" doom-user-dir))
   (progn
-    (shell-command "cp ~/.doom.d/user/examples/packages.el ~/.doom.d/user/packages.el")
+    (shell-command "cp ~/.config/doom/user/examples/packages.el ~/.config/doom/user/packages.el")
     (load (expand-file-name "user/packages.el" doom-user-dir))))

--- a/user/examples/config.el
+++ b/user/examples/config.el
@@ -61,7 +61,7 @@
 
 ;; Ignoring some folders on search
 (after! projectile
-  (setq projectile-globally-ignored-directories '("flow-typed" "node_modules" "~/.emacs.d/.local/" ".idea" ".vscode" ".ensime_cache" ".eunit" ".git" ".hg" ".fslckout" "_FOSSIL_" ".bzr" "_darcs" ".tox" ".svn" ".stack-work" ".ccls-cache" ".cache" ".clangd")))
+  (setq projectile-globally-ignored-directories '("flow-typed" "node_modules" "~/.config/emacs/.local/" ".idea" ".vscode" ".ensime_cache" ".eunit" ".git" ".hg" ".fslckout" "_FOSSIL_" ".bzr" "_darcs" ".tox" ".svn" ".stack-work" ".ccls-cache" ".cache" ".clangd")))
 
 ;; Add your custom searches (in rails folders)
 (after! projectile-rails


### PR DESCRIPTION
Update paths in files to use `~/.config/emacs` and `~/.config/doom` instead of the old paths `~/.emacs.d` and
`~/.doom.d`